### PR TITLE
[프로그래머스] 디스크 컨트롤러, 이중우선순위큐

### DIFF
--- a/힙/디스크 컨트롤러_현지연.py
+++ b/힙/디스크 컨트롤러_현지연.py
@@ -1,0 +1,30 @@
+import heapq
+
+def solution(jobs):
+    answer = 0      # 작업의 요청부터 종료까지 기다린 시간 합계
+    l = len(jobs)   # 작업의 개수
+    
+    heapq.heapify(jobs)                         # 리스트를 힙으로 변환
+    wait_list  = [(jobs[0][1], jobs[0][0])]     # 현재 시각 기준으로 요청이 들어온 작업 목록. (쇼요시간, 요청시점) 형태
+    time = jobs[0][0]                           # 현재 시각 초기화
+    heapq.heappop(jobs)                         # 첫번째 작업 삭제
+    
+    
+    while wait_list:    # 요청 목록이 빌 때까지 반복
+        
+        now = heapq.heappop(wait_list)  # 요청 목록에서 소요시간이 가장 적은 작업 빼내기
+        time += now[0]                  # 현재 시각 (종료 시각)
+        answer += (time - now[1])       # 요청부터 종료까지 기다린 시간 더하기
+        
+        # 현재 시각 기준 요청이 들어온 작업들을 요청 목록에 넣기
+        while (jobs and jobs[0][0] <= time):                
+            req_time, duration = heapq.heappop(jobs)
+            heapq.heappush(wait_list, (duration, req_time))
+            
+        # 현재 시각 기준 요청이 아예 없지만 작업 목록은 아직 남아있을 경우 현재 시각을 다음 요청 시각으로 옮기기
+        if not wait_list and jobs:
+            req_time, duration = heapq.heappop(jobs)
+            heapq.heappush(wait_list, (duration, req_time))
+            time = req_time
+        
+    return answer // l      # 작업의 요청부터 종료까지 걸린 시간 합계를 작업의 개수로 나눔(소수점 이하의 수는 버림)

--- a/힙/이중우선순위큐_현지연.py
+++ b/힙/이중우선순위큐_현지연.py
@@ -1,0 +1,35 @@
+import heapq
+def solution(operations):    
+    max_h = []  # 최대 힙
+    min_h = []  # 최소 힙
+    count = 0   # 원소의 개수
+    
+    for operation in operations:
+        c, n = operation.split()    # 명령어, 데이터
+        n = int(n)
+        # 데이터 추가
+        if c == 'I':
+            heapq.heappush(max_h, -n)   # 최대 힙에 부호 반대로 삽입
+            heapq.heappush(min_h, n)    # 최소 힙에 그대로 삽입
+            count += 1                  # 개수 1 더하기
+        # 데이터 삭제
+        else:
+            if n == 1 and max_h:        # 최댓값 삭제
+                heapq.heappop(max_h)
+            elif min_h:                 # 최솟값 삭제
+                heapq.heappop(min_h)
+            if len(max_h) + len(min_h) == count:    # 최대힙과 최소힙 초기화
+                max_h = []
+                min_h = []
+                count = 0
+    
+    # 비어있을 경우, 0 리턴
+    if count == 0:
+        return [0,0]
+        
+    # 현재 테스트케이스들을 풀리지만 오류가 있는 코드
+    # return [-heapq.heappop(max_h), heapq.heappop(min_h)]
+    
+    max_h = [-x for x in max_h]         # 최대 힙의 원소들을 원래 부호로 되돌림
+    final = set(max_h) & set(min_h)     # 힙을 집합으로 만들고 교집합을 구함
+    return [max(final), min(final)]     # 교집합에서 최댓값과 최솟값을 리턴


### PR DESCRIPTION
🍪 문제
프로그래머스 디스크 컨트롤러
https://school.programmers.co.kr/learn/courses/30/lessons/42627

🍊 문제 정의
`Input`
jobs: [작업이 요청되는 시점, 작업의 소요시간]을 담은 2차원 배열

`Output`
작업의 요청부터 종료까지 걸린 시간의 평균을 가장 줄이는 방법으로 처리한 평균

🍑 알고리즘 설계
전체 설계: 평균을 가장 줄이는 방법은 요청이 들어온 작업들 중에서 소요시간이 작은 작업부터 실행해야 함 -> 왜 그런지는 아직 이해 못했음

wait_list: 현재 시각 기준으로 요청 목록을 만들어서 (쇼요시간, 요청시점) 형태로 저장할 예정.
현재 시각 기준 요청이 들어온 작업들을 요청 목록으로 옮긴다
요청 목록에서 소요시간이 가장 작은 작업을 실행한다.

예외 처리: 요청 목록을 다 실행했음에도 불구하고 작업 목록이 남아있을 경우, 예를 들어 10ms시점에 작업이 끝났는데 다음 요청은 12ms에 들어올 경우
가장 가까운 시간의 작업을 요청 목록으로 저장하고 현재 시각을 옮긴다.

🍰 특이 사항 (Optional)
heapq: 힙 기능을 제공하는 라이브러리이다. 우선순위 큐 기능을 구현하기 위해 사용한다. 

```
import heapq
heapify(h)                # 기존 리스트를 힙으로 변환
heapq.heappush(h, value) # 힙에 삽입
heapq.heappop(h)          # 힙에서 최솟값 pop
```
<hr>

🍪 문제
프로그래머스 이중우선순위큐
https://school.programmers.co.kr/learn/courses/30/lessons/42628

🍊 문제 정의
`Input`
operations: “명령어 데이터” 형식을 담은 문자열 배열

`Output`
큐가 비어있으면 [0,0]
비어있지 않으면 [최댓값, 최솟값]

🍑 알고리즘 설계
최소 힙에는 데이터를 그대로 저장한다.
최대 힙에는 데이터 부호를 반대로 저장한다.
최소 힙과 최대 힙에 데이터를 동시에 저장한다.

최댓값을 삭제할 때는 최대 힙에서 삭제한다.
최솟값을 삭제할 때는 최소 힙에서 삭제한다.

최대 힙의 크기와 최소 힙의 크기의 합이 데이터를 추가한 개수와 같다면
최대 힙과 최소 힙을 초기화 한다.

연산이 다 끝나면, 
힙이 비어있을 경우 [0,0]을 리턴한다.
힙이 비어있지 않은 경우, 최대 힙의 원소들을 원래 부호로 되돌리고
최대 힙과 최소 힙의 교집합을 구한다.
교집합에서 최댓값과 최솟값을 리턴한다.

* 현재 테스트 케이스는 다양하지 않아서 예외처리를 못잡고있다...
예를 들어 아래와 같은 경우 예외를 못잡아냄
max_h = [-5643, 16]
min_h = [5643]


🍰 특이 사항 (Optional)
```
# a, b는 집합일 때
print(a | b)  # 합집합
print(a & b)  # 교집합
print(a - b)  # 차집합
```
